### PR TITLE
keeping track of resolved challenge sequence number

### DIFF
--- a/contracts/Front/Challenges.sol
+++ b/contracts/Front/Challenges.sol
@@ -43,7 +43,9 @@ contract Challenges is Base {
 
     mapping(bytes32 => Challenge) public challenges;
 
-    constructor(Head _head) public Base(_head) { }
+    constructor(Head _head) public Base(_head) {
+        nextChallengeSequenceNumber = 1;
+    }
 
     function() public payable {}
 

--- a/contracts/Storage/AtlasStakeStore.sol
+++ b/contracts/Storage/AtlasStakeStore.sol
@@ -72,7 +72,6 @@ contract AtlasStakeStore is Base {
 
     function updateLastChallengeResolvedSequenceNumber(address node, uint updatedLastChallengeResolvedSequenceNumber) public onlyContextInternalCalls {
         require(isStaking(node));
-        require(stakes[node].lastChallengeResolvedSequenceNumber <= updatedLastChallengeResolvedSequenceNumber);
         stakes[node].lastChallengeResolvedSequenceNumber = updatedLastChallengeResolvedSequenceNumber;
     }
 

--- a/test/contracts/front/challenges.js
+++ b/test/contracts/front/challenges.js
@@ -87,8 +87,8 @@ describe('Challenges Contract', () => {
     systemFee = fee.mul(new BN(SYSTEM_CHALLENGES_COUNT));
   });
 
-  it('nextChallengeSequenceNumber = 0 after deployment', async () => {
-    expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal('0');
+  it('nextChallengeSequenceNumber = 1 after deployment', async () => {
+    expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal('1');
   });
 
   describe('Starting system challenges', () => {
@@ -108,20 +108,20 @@ describe('Challenges Contract', () => {
 
     it(`Should increase nextChallengeSequenceNumber by challengesCount`, async () => {
       await challenges.methods.startForSystem(from, bundleId, SYSTEM_CHALLENGES_COUNT).send({from, value: systemFee});
-      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal(SYSTEM_CHALLENGES_COUNT.toString());
+      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal((SYSTEM_CHALLENGES_COUNT + 1).toString());
       await bundleStore.methods.store(otherBundleId, from, storagePeriods).send({from});
       await challenges.methods.startForSystem(from, otherBundleId, 100).send({from, value: fee.mul(new BN('100'))});
-      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal((SYSTEM_CHALLENGES_COUNT + 100).toString());
+      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal((SYSTEM_CHALLENGES_COUNT + 101).toString());
     });
 
     it('sets challenge sequence number to nextChallengeSequenceNumber', async () => {
       await challenges.methods.startForSystem(from, bundleId, SYSTEM_CHALLENGES_COUNT).send({from, value: systemFee});
-      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('0');
+      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('1');
 
       await bundleStore.methods.store(otherBundleId, from, storagePeriods).send({from});
       await challenges.methods.startForSystem(from, otherBundleId, 100).send({from, value: fee.mul(new BN('100'))});
       const otherChallengeId = await challenges.methods.getChallengeId(from, otherBundleId).call();
-      expect(await challenges.methods.getChallengeSequenceNumber(otherChallengeId).call()).to.equal(SYSTEM_CHALLENGES_COUNT.toString());
+      expect(await challenges.methods.getChallengeSequenceNumber(otherChallengeId).call()).to.equal((SYSTEM_CHALLENGES_COUNT + 1).toString());
     });
 
     it('Stores challengerId as 0x0', async () => {
@@ -218,14 +218,14 @@ describe('Challenges Contract', () => {
       await challenges.methods.startForSystem(from, bundleId, SYSTEM_CHALLENGES_COUNT).send({from, value: systemFee});
 
       await challenges.methods.start(other, bundleId).send({from, value: fee});
-      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal((SYSTEM_CHALLENGES_COUNT + 1).toString());
+      expect(await challenges.methods.nextChallengeSequenceNumber().call()).to.equal((SYSTEM_CHALLENGES_COUNT + 2).toString());
     });
 
     it('sets challenge sequence number to nextChallengeSequenceNumber', async () => {
       await challenges.methods.startForSystem(from, bundleId, SYSTEM_CHALLENGES_COUNT).send({from, value: systemFee});
 
       await challenges.methods.start(other, bundleId).send({from, value: fee});
-      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal(SYSTEM_CHALLENGES_COUNT.toString());
+      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal((SYSTEM_CHALLENGES_COUNT + 1).toString());
     });
 
     it('Fails if bundle is not being sheltered by provided account', async () => {
@@ -390,9 +390,9 @@ describe('Challenges Contract', () => {
       const systemFee = fee.mul(new BN('2'));
       await challenges.methods.startForSystem(from, bundleId, 2).send({from, value: systemFee});
       challengeId = await lastChallengeId();
-      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('1');
-      await challenges.methods.resolve(challengeId).send({from: resolver});
       expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('2');
+      await challenges.methods.resolve(challengeId).send({from: resolver});
+      expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('3');
       await challenges.methods.resolve(challengeId).send({from: totalStranger});
       expect(await challenges.methods.getChallengeSequenceNumber(challengeId).call()).to.equal('0');
     });

--- a/test/contracts/storage/atlas_stake_store.js
+++ b/test/contracts/storage/atlas_stake_store.js
@@ -81,14 +81,6 @@ describe('AtlasStakeStore Contract', () => {
       await expect(atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 1).send({from: other})).to.be.eventually.rejected;
     });
 
-    it('new value has to be not smaller than current one', async () => {
-      await atlasStakeStore.methods.depositStake(from, 1).send({from, value: 1});
-      await atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 100).send({from});
-      await expect(atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 99).send({from})).to.be.eventually.rejected;
-      await expect(atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 100).send({from})).to.be.eventually.fulfilled;
-      await expect(atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 101).send({from})).to.be.eventually.fulfilled;
-    });
-
     it('updates last challenge resolved sequence number', async () => {
       await atlasStakeStore.methods.depositStake(from, 1).send({from, value: 1});
       await atlasStakeStore.methods.updateLastChallengeResolvedSequenceNumber(from, 100).send({from});


### PR DESCRIPTION
Had to put `<= ` statement while updating `lastChallengeResolvedSequenceNumber `. Because at the beginning all will be zero. Alternatively we can start counting challenges from `1`, but I think we can keep it as it is and make sure no invalid operations will be performed, while implementing the rest of cooldown mechanism.