### PR TITLE
Simple block reward contract added

### DIFF
--- a/contracts/Consensus/BlockRewards.sol
+++ b/contracts/Consensus/BlockRewards.sol
@@ -1,0 +1,65 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+
+pragma solidity ^0.4.22;
+
+// From: https://wiki.parity.io/Block-Reward-Contract
+contract BlockRewardsBase {
+    // produce rewards for the given benefactors, with corresponding reward codes.
+    // only callable by `SUPER_USER`
+    function reward(address[] benefactors, uint16[] kind) external returns (address[], uint256[]);
+}
+
+/**
+@title Implementation of Parities Block Reward contract with:
+- rewards given only to registered validator 
+- rewards amount proportional to `share` assigned to each validator
+*/
+contract BlockRewards is BlockRewardsBase {
+    address public owner;
+    address private superUser; // the SUPER_USER address as defined by EIP96. During normal operation should be 2**160 - 2
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+    @notice Constructor
+    @param _owner the owner of this contract, that can add/remove valiators and their share.
+    @param _superUser SUPER_USER address value injectable for test purpouses. Under normal operation it should be set to 2^160-2 as defined in EIP96 
+    */
+    constructor(address _owner, address _superUser) public {
+        owner = _owner;
+        superUser = _superUser;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "sender must be owner");
+        _;
+    }
+
+    function transferOwnership(address newOwner) public onlyOwner {
+        require(newOwner != address(0), "New owner must not be 0x0");
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function reward(address[] benefactors, uint16[] kind) external returns (address[], uint256[]) {
+        require(msg.sender == superUser, "Must be called by super user");
+        require(benefactors.length == kind.length, "Input lists need to be of equal length");
+
+        address[] memory retAddresses = new address[](benefactors.length);
+        uint256[] memory retAmounts = new uint256[](benefactors.length);
+
+        for (uint i = 0; i < benefactors.length; i++) {
+            retAddresses[i] = benefactors[i];
+            retAmounts[i] = 1 ether;
+        }
+
+        return (retAddresses, retAmounts);
+    }
+}

--- a/contracts/Consensus/ValidatorSet.sol
+++ b/contracts/Consensus/ValidatorSet.sol
@@ -15,6 +15,7 @@ contract ValidatorSetBase {
     event InitiateChange(bytes32 indexed parentHash, address[] newSet);
 
     function getValidators() public view returns (address[]); 
+    // Called by the `SUPER_USER` in response of to a InitiateChange event.    
     function finalizeChange() public;
 }
 
@@ -26,8 +27,7 @@ contract ValidatorSetBase {
 */
 contract ValidatorSet is ValidatorSetBase {
     address public owner;
-    // the SUPER_USER address as defined by EIP96. During normal operation should be 2**160 - 2
-    address private superUser;
+    address private superUser; // the SUPER_USER address as defined by EIP96. During normal operation should be 2**160 - 2
     address[] public validators;
     address[] public pendingValidators;
 
@@ -35,7 +35,7 @@ contract ValidatorSet is ValidatorSetBase {
 
     /**
     @notice Constructor
-    @param _owner the owner of this contract.
+    @param _owner the owner of this contract, that can add/remove validators.
     @param _initialValidators the initial set of validator addresses.
     @param _superUser SUPER_USER address value injectable for test purpouses. Under normal operation it should be set to 2^160-2 as defined in EIP96 
     */

--- a/test/contracts/consensus/block_rewards.js
+++ b/test/contracts/consensus/block_rewards.js
@@ -1,0 +1,105 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {createWeb3, deployContract} from '../../../src/utils/web3_tools';
+import chaiEmitEvents from '../../helpers/chaiEmitEvents';
+import BlockRewardsJson from '../../../build/contracts/BlockRewards.json';
+
+const {expect} = chai;
+chai.use(chaiAsPromised);
+chai.use(chaiEmitEvents);
+
+describe('Block rewards contract', () => {
+  const standardOptions = {
+    gas: 1000000
+  };
+
+  const deploy = async (web3, sender, superUser) => deployContract(web3, BlockRewardsJson, [sender, superUser], {from: sender});
+  const getOwner = async (contract) => contract.methods.owner().call();
+  const transferOwnership = async (contract, sender, newOwner) => contract.methods.transferOwnership(newOwner).send({...standardOptions, from: sender});
+  const reward = async (contract, sender, benefactors, kind) => contract.methods.reward(benefactors, kind).call({from: sender});
+
+  let web3;
+  let owner;
+  let otherUser;
+  let superUser;
+  let newOwner;
+  let exampleBenefactors;
+
+  before(async () => {
+    web3 = await createWeb3();
+    [owner, otherUser, superUser, newOwner] = await web3.eth.getAccounts();
+    exampleBenefactors = Array(3)
+      .fill(null)
+      .map(() => web3.eth.accounts.create().address);
+  });
+
+  describe('constructor', () => {
+    let contract;
+
+    before(async () => {
+      contract = await deploy(web3, owner, superUser);
+    });
+
+    it('sets the owner', async () => {
+      const storedOwner = await getOwner(contract);
+      expect(storedOwner).to.equal(owner);
+    });
+  });
+
+  describe('transferring ownership', () => {
+    let contract;
+
+    beforeEach(async () => {
+      contract = await deploy(web3, owner, superUser);
+    });
+
+    it('sets the new owner', async () => {
+      await expect(transferOwnership(contract, owner, newOwner)).to.be.fulfilled;
+      expect(await getOwner(contract)).to.equal(newOwner);
+    });
+
+    it('emits a OwnershipTransferred event', async () => {
+      expect(await transferOwnership(contract, owner, newOwner)).to.emitEvent('OwnershipTransferred');
+    });
+
+    it(`can't be invoked by non-owner`, async () => {
+      await expect(transferOwnership(contract, otherUser, newOwner)).to.be.rejected;
+    });
+  });
+
+  describe('reward', () => {
+    let contract;
+    let kinds;
+    let oneEther;
+
+    beforeEach(async () => {
+      contract = await deploy(web3, owner, superUser);
+      kinds = Array(exampleBenefactors.length).fill(0);
+      oneEther = web3.utils.toWei('1', 'ether');
+    });
+
+    it('assigns a reward of 1 ether to every address provided in the parameters', async () => {
+      const rewards = await reward(contract, superUser, exampleBenefactors, kinds);
+      const {0 : rewardedAddresses, 1 : rewardedValues} = rewards;
+      expect(rewardedAddresses).to.have.members(exampleBenefactors);
+      expect(rewardedValues).to.deep.equal(Array(exampleBenefactors.length).fill(oneEther));
+    });
+
+    it('fails if a different number of benefactors and reward kinds is provided', async () => {
+      await expect(reward(contract, superUser, exampleBenefactors, kinds.slice(1))).to.be.rejected;
+    });
+
+    it('fails for non-SUPER_USER', async () => {
+      await expect(reward(contract, owner, exampleBenefactors, kinds)).to.be.rejected;
+    });
+  });
+});

--- a/test/contracts/consensus/validator_set.js
+++ b/test/contracts/consensus/validator_set.js
@@ -24,12 +24,12 @@ describe('Validator set contract', () => {
 
   const deploy = async (web3, sender, initialValidators, superUser) => deployContract(web3, ValidatorSetJson, [sender, initialValidators, superUser], {from: sender});
   const getOwner = async (contract) => contract.methods.owner().call();
+  const transferOwnership = async (contract, sender, newOwner) => contract.methods.transferOwnership(newOwner).send({...standardOptions, from: sender});
   const addValidator = async (contract, sender, validator) => contract.methods.addValidator(validator).send({...standardOptions, from: sender});
   const removeValidator = async (contract, sender, validator) => contract.methods.removeValidator(validator).send({...standardOptions, from: sender});
   const getValidators = async (contract) => contract.methods.getValidators().call();
   const getPendingValidators = async (contract) => contract.methods.getPendingValidators().call();
   const finalizeChange = async (contract, sender) => contract.methods.finalizeChange().send({...standardOptions, from: sender});
-  const transferOwnership = async (contract, sender, newOwner) => contract.methods.transferOwnership(newOwner).send({...standardOptions, from: sender});
 
   let web3;
   let owner;


### PR DESCRIPTION
A very simple block reward contract. For now only gives 1 ether to whoever is provided into the `reward` method.

Planed work for further PR: 
- Extract `GenesisOwnable` from validator set and block reward contract
- Rewards dependent on the share