### PR TITLE
CI speed improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 dist: trusty
 language: node_js
-cache: yarn
+cache: 
+  yarn: true
+  directories:
+  - node_modules
 node_js:
   - '9'
 install:
   - yarn install
-script:
-  - yarn testall
-  - ./scripts/test_cli.sh  
-  - yarn dev:lint
+jobs:
+  include:
+    - stage: test
+      script: 
+        - yarn build
+        - yarn dev:lint
+    - stage: test
+      script:
+        - yarn build
+        - yarn test
+    - stage: test
+      script:
+        - yarn build
+        - ./scripts/test_cli.sh

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-header": "^1.2.0",
     "eslint-plugin-import": "^2.12.0",
     "ganache-core": "^2.1.0",
+    "memdown": "^1.3.1",
     "mocha": "^5.1.1",
     "sinon": "^6.1.4",
     "sinon-chai": "^3.2.0",

--- a/src/utils/web3_tools.js
+++ b/src/utils/web3_tools.js
@@ -46,7 +46,11 @@ export async function createGanacheServer(secretKey) {
 function createGanacheProvider(secretKey) {
   // import in code with purpose:D
   const Ganache = require('ganache-core');
-  return Ganache.provider(getDefaultGanacheOptions(secretKey));
+  const memdown = require('memdown');
+  return Ganache.provider({
+    ...getDefaultGanacheOptions(secretKey),
+    db: memdown()
+  });
 }
 
 async function ganacheTopUpDefaultAccount(web3) {

--- a/test/mocha_env.js
+++ b/test/mocha_env.js
@@ -7,6 +7,7 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 */
 
+require('events').EventEmitter.defaultMaxListeners = 100;
 process.env.NODE_ENV = 'test';
 process.env.WEB3_RPC = 'ganache';
 process.env.WEB3_NODEPRIVATEKEY = '0xfa654acfc59f0e4fe3bd57082ad28fbba574ac55fe96e915f17de27ad9c77696';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,7 +3541,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memdown@^1.0.0:
+memdown@^1.0.0, memdown@^1.3.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/memdown/-/memdown-1.4.1.tgz#b4e4e192174664ffbae41361aa500f3119efe215"
   dependencies:


### PR DESCRIPTION
- Building contract separated from running tests
- Linter runs first
- Linter, unit and integration tests run in separate travis stages
- MemDown for ganache speed improvements
- node_modules caching