### PR TITLE
Support generating raw data from wrappers, instead of sending transactions

### DIFF
--- a/src/wrappers/challenges_wrapper.js
+++ b/src/wrappers/challenges_wrapper.js
@@ -36,7 +36,7 @@ export default class ChallengesWrapper extends ContractWrapper {
 
   async resolve(challengeId) {
     const contract = await this.contract();
-    return contract.methods.resolve(challengeId).send({from: this.defaultAddress});
+    return this.processTransaction(contract.methods.resolve(challengeId));
   }
 
   async canResolve(challengeId) {

--- a/src/wrappers/contract_wrapper.js
+++ b/src/wrappers/contract_wrapper.js
@@ -12,10 +12,11 @@ import contractJsons from '../contract_jsons';
 
 /** @abstract */
 export default class ContractWrapper {
-  constructor(headWrapper, web3, defaultAddress) {
+  constructor(headWrapper, web3, defaultAddress, sendTransactions) {
     this.headWrapper = headWrapper;
     this.web3 = web3;
     this.defaultAddress = defaultAddress;
+    this.sendTransactions = sendTransactions;
   }
 
   async contract() {
@@ -25,6 +26,13 @@ export default class ContractWrapper {
 
   get getContractName() {
     throw new Error('Abstract method getContractName needs to be overridden');
+  }
+
+  async processTransaction(transactionObject, sendParams = {}) {
+    if (this.sendTransactions) {
+      return transactionObject.send({from: this.defaultAddress, ...sendParams});
+    }
+    return transactionObject.encodeABI();
   }
 
   setDefaultAddress(defaultAddress) {

--- a/src/wrappers/kyc_whitelist_wrapper.js
+++ b/src/wrappers/kyc_whitelist_wrapper.js
@@ -16,12 +16,12 @@ export default class KycWhitelistWrapper extends ContractWrapper {
 
   async add(address, role, requiredDeposit) {
     const contract = await this.contract();
-    await contract.methods.add(address, role, requiredDeposit).send({from: this.defaultAddress});
+    return this.processTransaction(contract.methods.add(address, role, requiredDeposit));
   }
 
   async remove(address) {
     const contract = await this.contract();
-    await contract.methods.remove(address).send({from: this.defaultAddress});
+    return this.processTransaction(contract.methods.remove(address));
   }
 
   async isWhitelisted(address) {

--- a/src/wrappers/roles_wrapper.js
+++ b/src/wrappers/roles_wrapper.js
@@ -26,7 +26,7 @@ export default class RolesWrapper extends ContractWrapper {
 
   async onboardAsApollo(address, deposit) {
     const contract = await this.contract();
-    return contract.methods.onboardAsApollo().send({
+    return this.processTransaction(contract.methods.onboardAsApollo(), {
       from: address,
       value: deposit
     });
@@ -34,7 +34,7 @@ export default class RolesWrapper extends ContractWrapper {
 
   async onboardAsAtlas(address, stake, url) {
     const contract = await this.contract();
-    return contract.methods.onboardAsAtlas(url).send({
+    return this.processTransaction(contract.methods.onboardAsAtlas(url), {
       from: address,
       value: stake
     });
@@ -42,7 +42,7 @@ export default class RolesWrapper extends ContractWrapper {
 
   async onboardAsHermes(address, url) {
     const contract = await this.contract();
-    return contract.methods.onboardAsHermes(url).send({
+    return this.processTransaction(contract.methods.onboardAsHermes(url), {
       from: address
     });
   }

--- a/src/wrappers/uploads_wrapper.js
+++ b/src/wrappers/uploads_wrapper.js
@@ -16,9 +16,6 @@ export default class UploadsWrapper extends ContractWrapper {
 
   async registerBundle(bundleId, fee, storagePeriods) {
     const contract = await this.contract();
-    return contract
-      .methods
-      .registerBundle(bundleId, storagePeriods)
-      .send({from: this.defaultAddress, value: fee});
+    return this.processTransaction(contract.methods.registerBundle(bundleId, storagePeriods), {from: this.defaultAddress, value: fee});
   }
 }

--- a/test/contracts/front/challenges.js
+++ b/test/contracts/front/challenges.js
@@ -256,7 +256,6 @@ describe('Challenges Contract', () => {
 
     it(`Should increase nextChallengeSequenceNumber by 1`, async () => {
       await startChallengeForSystem(from, bundleId, SYSTEM_CHALLENGES_COUNT, from, systemChallengeFee);
-
       await startChallenge(other, bundleId, from, userChallengeFee);
       expect(await nextChallengeSequenceNumber()).to.equal((SYSTEM_CHALLENGES_COUNT + 2).toString());
     });

--- a/test/wrappers/uploads_wrapper.js
+++ b/test/wrappers/uploads_wrapper.js
@@ -8,7 +8,7 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 */
 
 import chai from 'chai';
-import sinon from 'sinon';
+import sinon, {resetHistory} from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import UploadsWrapper from '../../src/wrappers/uploads_wrapper';
@@ -26,32 +26,59 @@ describe('Uploads Wrapper', () => {
     const storagePeriods = 23;
     const defaultAccount = '0x123';
     const fee = '100';
+    const exampleData = '0xda7a';
+    const encodeAbiStub = sinon.stub().resolves(exampleData);
+    let contractMock;
     let registerBundleStub;
     let registerBundleSendStub;
 
-    beforeEach(async () => {
+    before(async () => {
       registerBundleStub = sinon.stub();
       registerBundleSendStub = sinon.stub();
-      const contractMock = {
+      contractMock = {
         methods: {
           registerBundle: registerBundleStub
         }
       };
       registerBundleStub.returns({
-        send: registerBundleSendStub
+        send: registerBundleSendStub,
+        encodeABI: encodeAbiStub
       });
-      uploadsWrapper = new UploadsWrapper({}, {}, defaultAccount);
-      getContractStub = sinon.stub(uploadsWrapper, 'contract').resolves(contractMock);
     });
 
-    afterEach(async () => {
+    afterEach(() => {
+      resetHistory(contractMock);
+    });
+
+    after(async () => {
       getContractStub.restore();
     });
 
-    it('calls contract method with correct arguments', async () => {
-      await uploadsWrapper.registerBundle(bundleId, fee, storagePeriods);
-      expect(registerBundleStub).to.be.calledOnceWith(bundleId, storagePeriods);
-      expect(registerBundleSendStub).to.be.calledOnceWith({from: defaultAccount, value: fee});
+    describe('sendTransactions = true', () => {
+      before(() => {
+        uploadsWrapper = new UploadsWrapper({}, {}, defaultAccount, true);
+        getContractStub = sinon.stub(uploadsWrapper, 'contract').resolves(contractMock);
+      });
+
+      it('calls contract method with correct arguments', async () => {
+        await uploadsWrapper.registerBundle(bundleId, fee, storagePeriods);
+        expect(registerBundleStub).to.be.calledOnceWith(bundleId, storagePeriods);
+        expect(registerBundleSendStub).to.be.calledOnceWith({from: defaultAccount, value: fee});
+      });
+    });
+
+    describe('sendTransactions = false', () => {
+      before(() => {
+        uploadsWrapper = new UploadsWrapper({}, {}, defaultAccount, false);
+        getContractStub = sinon.stub(uploadsWrapper, 'contract').resolves(contractMock);
+      });
+
+      it('returns data', async () => {
+        expect(await uploadsWrapper.registerBundle(bundleId, fee, storagePeriods)).to.equal(exampleData);
+        expect(registerBundleStub).to.be.calledWith(bundleId, storagePeriods);
+        expect(registerBundleSendStub).to.be.not.called;
+        expect(encodeAbiStub).to.be.calledOnceWith();
+      });
     });
   });
 });


### PR DESCRIPTION
sendTransaction parameter is passed to every wrapper indicating if perform transactions or return data