### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:9
+
+WORKDIR /app
+
+COPY ./package.json ./yarn.lock /app/
+
+RUN yarn install
+
+COPY . ./
+
+RUN yarn build
+
+CMD ["yarn", "start"]


### PR DESCRIPTION
Adds a Dockerfile for portability. We use the Dockerfile to deploy
contracts and onboard nodes together with Ansible.